### PR TITLE
support multiple namespaces

### DIFF
--- a/lib/middleman-thumbnailer/extension.rb
+++ b/lib/middleman-thumbnailer/extension.rb
@@ -80,7 +80,7 @@ module Middleman
     class DirGlob
       def self.glob(root, namespaces, filetypes)
         filetypes_with_capitals = filetypes.reduce([]) { |memo, file| memo.concat [file, file.upcase] }
-        glob_str = "#{root}/#{namespaces.join(',')}/**/*.{#{filetypes_with_capitals.join(',')}}"
+        glob_str = "#{root}/{#{namespaces.join(',')}}/**/*.{#{filetypes_with_capitals.join(',')}}"
         Dir[glob_str]
       end
     end


### PR DESCRIPTION
Allow the :namespace_directory option to be set to an array of directories:

:namespace_directory => %w(gallery other_gallery1 other_gallery2)

The above will generate thumbnails for images in:
- images/gallery
- images/other_gallery1
- images/other_gallery2